### PR TITLE
Cap internal buffer size for large array performance

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -22,7 +22,8 @@ var ErrGeneratorOverflow = fmt.Errorf("Write past end of bounded array/hash/ivar
 var ErrNonSymbolValue = fmt.Errorf("Non Symbol value written when Symbol expected")
 
 const (
-	genStateGrowSize = 8 // Initial size + amount to grow state stack by
+	maxBufferSize    = 512 // Flush buffer when it exceeds this threshold
+	genStateGrowSize = 8   // Initial size + amount to grow state stack by
 	symTblGrowSize   = 8
 )
 
@@ -558,7 +559,7 @@ func (gen *Generator) writeAdv() error {
 
 	// If we've just finished writing out the last value, then we make sure to flush anything remaining.
 	// Otherwise, we let things accumulate in our small buffer between calls to reduce the number of writes.
-	if gen.bufn > 0 && gen.st.cur.pos == gen.st.cur.cnt && gen.st.sz == 1 {
+	if gen.bufn > maxBufferSize || (gen.bufn > 0 && gen.st.cur.pos == gen.st.cur.cnt && gen.st.sz == 1) {
 		if _, err := gen.w.Write(gen.buf[:gen.bufn]); err != nil {
 			return err
 		}

--- a/generator_test.go
+++ b/generator_test.go
@@ -241,11 +241,11 @@ func BenchmarkGenLargeArray(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		gen.Reset(nil)
 
-		if err := gen.StartArray(10); err != nil {
+		if err := gen.StartArray(50000); err != nil {
 			b.Fatal(err)
 		}
-		for i := 0; i < 10; i++ {
-			if err := gen.Nil(); err != nil {
+		for i := 0; i < 50000; i++ {
+			if err := gen.String("somebytes"); err != nil {
 				b.Fatal(err)
 			}
 		}


### PR DESCRIPTION
I was seeing some performance issues with marshalling large arrays where just a few thousands of complex objects were marshalled for 20+ seconds.

Digging deeper, it seems to be due to internal buffer management and step-wise growing of the buffer for each operation that extends the buffer beyond initial 128 bytes.

https://github.com/samcday/rmarsh/blob/69f255aa99588b25fd0891af2a34d31c0c3a0608/generator.go#L538-L544

Doing `copy` for each operation on smaller buffer sizes has negligible performance impact, however, as the buffer size grows, the impact becomes significant.  In my large-array situation, given that all array elements are being buffered until `EndArray` is called, this problem goes from bad to worse as array size grows.

This PR flushes the buffer at 512 to limit its growth and reduce the performance penalty.

Performance before the changes:

```
$ go test -bench BenchmarkGenLargeArray *.go
goos: darwin
goarch: amd64
BenchmarkGenLargeArray-4   	       1	2112491558 ns/op
PASS
ok  	command-line-arguments	2.431s
```
Performance after the changes (*almost 1900 times faster*):

```
$ go test -bench BenchmarkGenLargeArray *.go
goos: darwin
goarch: amd64
BenchmarkGenLargeArray-4   	    2000	   1126527 ns/op
PASS
ok  	command-line-arguments	2.614s
```



