### PR TITLE
Improve performance by using append to populate and grow buffer

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -22,7 +22,8 @@ var ErrGeneratorOverflow = fmt.Errorf("Write past end of bounded array/hash/ivar
 var ErrNonSymbolValue = fmt.Errorf("Non Symbol value written when Symbol expected")
 
 const (
-	genStateGrowSize = 8 // Initial size + amount to grow state stack by
+	maxBufferSize    = 512 // Flush buffer when it exceeds this threshold
+	genStateGrowSize = 8   // Initial size + amount to grow state stack by
 	symTblGrowSize   = 8
 )
 
@@ -558,7 +559,7 @@ func (gen *Generator) writeAdv() error {
 
 	// If we've just finished writing out the last value, then we make sure to flush anything remaining.
 	// Otherwise, we let things accumulate in our small buffer between calls to reduce the number of writes.
-	if gen.bufn > 0 && gen.st.cur.pos == gen.st.cur.cnt && gen.st.sz == 1 {
+	if gen.bufn > maxBufferSize || (gen.bufn > 0 && gen.st.cur.pos == gen.st.cur.cnt && gen.st.sz == 1) {
 		if _, err := gen.w.Write(gen.buf[:gen.bufn]); err != nil {
 			return err
 		}

--- a/generator_test.go
+++ b/generator_test.go
@@ -241,11 +241,11 @@ func BenchmarkGenLargeArray(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		gen.Reset(nil)
 
-		if err := gen.StartArray(10); err != nil {
+		if err := gen.StartArray(50000); err != nil {
 			b.Fatal(err)
 		}
-		for i := 0; i < 10; i++ {
-			if err := gen.Nil(); err != nil {
+		for i := 0; i < 50000; i++ {
+			if err := gen.String("somebytes"); err != nil {
 				b.Fatal(err)
 			}
 		}


### PR DESCRIPTION
Following up on PR #1, I decided to try out different strategies to replace explicit buffer management in the current version of rmarsh Generator.  I tried using `bytes.Buffer`, `bufio.Writer`, and `append` and it looks like the latter is the best performing solution.

Here are the original performance numbers for manual buffer management in master:

```
BenchmarkGenReset-4         	500000000	         3.56 ns/op
BenchmarkGenNil-4           	100000000	        19.3 ns/op
BenchmarkGenBool-4          	100000000	        19.3 ns/op
BenchmarkGenFixnum-4        	100000000	        23.6 ns/op
BenchmarkGenBignum-4        	20000000	        67.1 ns/op
BenchmarkGenSymbol-4        	50000000	        30.5 ns/op
BenchmarkGenString-4        	50000000	        29.2 ns/op
BenchmarkGenFloat-4         	10000000	       222 ns/op
BenchmarkGenArray-4         	30000000	        41.1 ns/op
BenchmarkGenLargeArray-4    	    2000	   1051485 ns/op
BenchmarkGenHash-4          	20000000	        69.2 ns/op
BenchmarkGenClass-4         	50000000	        27.6 ns/op
BenchmarkGenModule-4        	50000000	        26.1 ns/op
BenchmarkGenIVar-4          	20000000	        87.6 ns/op
BenchmarkGenUserDefined-4   	50000000	        41.0 ns/op
BenchmarkGenStruct-4        	20000000	        80.4 ns/op
```

And here's the improved performance after switching to `append`:

```
BenchmarkGenReset-4         	300000000	         4.22 ns/op
BenchmarkGenNil-4           	100000000	        16.7 ns/op
BenchmarkGenBool-4          	100000000	        16.8 ns/op
BenchmarkGenFixnum-4        	100000000	        23.2 ns/op
BenchmarkGenBignum-4        	30000000	        48.9 ns/op
BenchmarkGenSymbol-4        	50000000	        30.7 ns/op
BenchmarkGenString-4        	50000000	        27.5 ns/op
BenchmarkGenFloat-4         	10000000	       220 ns/op
BenchmarkGenArray-4         	50000000	        36.1 ns/op
BenchmarkGenLargeArray-4    	    2000	    988043 ns/op
BenchmarkGenHash-4          	20000000	        63.7 ns/op
BenchmarkGenClass-4         	50000000	        25.2 ns/op
BenchmarkGenModule-4        	50000000	        25.7 ns/op
BenchmarkGenIVar-4          	20000000	        80.8 ns/op
BenchmarkGenUserDefined-4   	50000000	        40.0 ns/op
BenchmarkGenStruct-4        	20000000	        71.8 ns/op
```

The `bytes.Buffer` and `bufio.Writer` branches were much slower, so I didn't pursue those solutions.  However, if you'd like to take a look, they are here:
https://github.com/rykov/rmarsh/tree/buf-bytes
https://github.com/rykov/rmarsh/tree/buf-bufio
